### PR TITLE
Use an object specific local cache for faster repeated queries.

### DIFF
--- a/lack/src/main/java/io/datanerds/lack/CachedLack.java
+++ b/lack/src/main/java/io/datanerds/lack/CachedLack.java
@@ -1,0 +1,50 @@
+package io.datanerds.lack;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.datanerds.lack.cassandra.LackConfig;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.datanerds.lack.Messages.MESSAGE_ACQUIRE;
+
+public class CachedLack extends Lack {
+
+    private final Cache<String, Boolean> cache;
+
+    public CachedLack(LackConfig config, String owner, Cache<String, Boolean> cache) {
+        super(config, owner);
+        this.cache = cache;
+    }
+
+    public CachedLack(LackConfig config, String owner, long size) {
+        this(config, owner, CacheBuilder.newBuilder()
+                .maximumSize(size)
+                .expireAfterWrite(config.ttlInSeconds, TimeUnit.SECONDS)
+                .build());
+    }
+
+    @Override
+    public void acquire(String resource) throws LackException {
+        Boolean locked = cache.getIfPresent(resource);
+        if (locked != null && locked) {
+            throw new LackException(String.format(MESSAGE_ACQUIRE, resource));
+        }
+
+        super.acquire(resource);
+        cache.put(resource, true);
+    }
+
+    @Override
+    public void renew(String resource) throws LackException {
+        super.renew(resource);
+        cache.put(resource, true);
+    }
+
+    @Override
+    public void release(String resource) throws LackException {
+        super.release(resource);
+        cache.put(resource, false);
+    }
+
+}

--- a/lack/src/main/java/io/datanerds/lack/Lack.java
+++ b/lack/src/main/java/io/datanerds/lack/Lack.java
@@ -6,6 +6,8 @@ import io.datanerds.lack.cassandra.CassandraClient;
 import io.datanerds.lack.cassandra.LackConfig;
 import io.datanerds.lack.cassandra.Statements;
 
+import static io.datanerds.lack.Messages.*;
+
 public class Lack {
 
     private final String owner;
@@ -25,21 +27,21 @@ public class Lack {
     public void acquire(String resource) throws LackException {
         ResultSet result = statements.acquire(resource, owner);
         if (!result.wasApplied()) {
-            throw new LackException(String.format("Could not acquire lock for '%s'", resource));
+            throw new LackException(String.format(MESSAGE_ACQUIRE, resource));
         }
     }
 
     public void renew(String resource) throws LackException {
         ResultSet result = statements.renew(resource, owner);
         if (!result.wasApplied()) {
-            throw new LackException(String.format("Could not renew lock for '%s'", resource));
+            throw new LackException(String.format(MESSAGE_RENEW, resource));
         }
     }
 
     public void release(String resource) throws LackException {
         ResultSet result = statements.release(resource, owner);
         if (!result.wasApplied()) {
-            throw new LackException(String.format("Could not release lock for '%s'", resource));
+            throw new LackException(String.format(MESSAGE_RELEASE, resource));
         }
     }
 

--- a/lack/src/main/java/io/datanerds/lack/Messages.java
+++ b/lack/src/main/java/io/datanerds/lack/Messages.java
@@ -1,0 +1,9 @@
+package io.datanerds.lack;
+
+public interface Messages {
+
+    String MESSAGE_ACQUIRE = "Could not acquire lock for '%s'";
+    String MESSAGE_RENEW = "Could not renew lock for '%s'";
+    String MESSAGE_RELEASE = "Could not release lock for '%s'";
+
+}

--- a/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
+++ b/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
@@ -1,0 +1,117 @@
+package io.datanerds.lack;
+
+import com.google.common.cache.Cache;
+import io.datanerds.lack.cassandra.LackConfig;
+import org.cassandraunit.CassandraCQLUnit;
+import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CachedLackTest {
+
+    private static LackConfig config = new LackConfig(null, null, new String[]{"127.0.0.1"}, 9142, "lack", 1);
+
+    @Mock
+    private static Cache<String, Boolean> cache;
+    @Mock
+    private static Cache<String, Boolean> otherCache;
+
+    private static CachedLack cachedLack;
+    private static CachedLack otherCachedLack;
+    private String resource;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @ClassRule
+    public static CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(
+            new ClassPathCQLDataSet("setup.cql", "lack"));
+
+
+    @BeforeClass
+    public static void setupCassandra() throws Exception {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+    }
+
+    @Before
+    public void setup() {
+        this.resource = UUID.randomUUID().toString();
+
+        cachedLack = new CachedLack(config, "lack", cache);
+        otherCachedLack = new CachedLack(config, "otherLack", otherCache);
+    }
+
+    @Test
+    public void simpleAcquireRenewAndRelease() throws LackException {
+        cachedLack.acquire(resource);
+        cachedLack.renew(resource);
+        cachedLack.release(resource);
+
+        verify(cache, times(1)).getIfPresent(resource);
+        verify(cache, times(2)).put(resource, true);
+        verify(cache, times(1)).put(resource, false);
+    }
+
+    @Test
+    public void alreadyLocked() throws LackException {
+        cachedLack.acquire(resource);
+        thrown.expect(LackException.class);
+        cachedLack.acquire(resource);
+
+        verify(cache, times(2)).getIfPresent(resource);
+        verify(cache, times(1)).put(resource, true);
+        verify(cache, never()).put(resource, false);
+    }
+
+    @Test
+    public void alreadyLockedByOther() throws LackException {
+        cachedLack.acquire(resource);
+        thrown.expect(LackException.class);
+        otherCachedLack.acquire(resource);
+
+        verify(cache, times(1)).getIfPresent(resource);
+        verify(cache, times(1)).put(resource, true);
+        verify(cache, never()).put(resource, false);
+
+        verify(otherCache, times(1)).getIfPresent(resource);
+        verify(otherCache, never()).put(resource, true);
+        verify(otherCache, never()).put(resource, false);
+    }
+
+    @Test
+    public void alreadyReleased() throws LackException {
+        cachedLack.acquire(resource);
+        cachedLack.release(resource);
+        thrown.expect(LackException.class);
+        otherCachedLack.release(resource);
+
+        verify(cache, times(1)).getIfPresent(resource);
+        verify(cache, never()).put(resource, true);
+        verify(cache, times(1)).put(resource, false);
+
+        verify(otherCache, never()).getIfPresent(resource);
+        verify(otherCache, never()).put(resource, true);
+        verify(otherCache, never()).put(resource, false);
+    }
+
+    @Test
+    public void testReleaseAfterTtl() throws Exception {
+        cachedLack.acquire(resource);
+        Thread.sleep(1200);
+        cachedLack.acquire(resource);
+
+        verify(cache, times(2)).getIfPresent(resource);
+        verify(cache, times(2)).put(resource, true);
+        verify(cache, never()).put(resource, false);
+    }
+}


### PR DESCRIPTION
- located in new CachedLack subclass to make cache use optional
- minimal changes to Lack class to allow subclassing
- cache is local and specific to one Lack instance (objects sharing the same connection do not share the cache)
- using Guava Cache implementation
- Lack.acquire(resource) is performance critical if C\* queries are required for repeated queries
- local cache can be used to answer question if same instance was used to acquire/renew the lock, no C\* query required
- if the cache does not know the resource, fallback to superclass, same with renew/release
- cache uses both size and time based eviction, same TTL as C\* lock configuration
- tests mirror behavior specified in the Lack test specification and make sure the cache is used correctly
