### PR TITLE
Reacquiring owned lock results in renewing lease by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ lack.acquire("user-1");
 // Renewing the lock in case we need longer than 42 seconds:
 lack.renew("user-1");
 ...
+// Claiming the lock results in renewal in case we're already owning it and acquiring otherwise
+lack.claim("user-1");
+...
 // Releasing the lock in case we have finished our operation:
 lack.release("user-1");
 ```

--- a/lack/src/main/java/io/datanerds/lack/Lack.java
+++ b/lack/src/main/java/io/datanerds/lack/Lack.java
@@ -35,7 +35,7 @@ public class Lack {
     public void claim(String resource) throws LackException {
         ResultSet result = statements.acquire(resource, owner);
         if (!result.wasApplied()) {
-            checkLockOwner(resource, result);
+            renewIfOwned(resource, result);
         }
     }
 
@@ -58,7 +58,7 @@ public class Lack {
         client.close();
     }
 
-    private void checkLockOwner(String resource,  ResultSet result) throws LackException {
+    private void renewIfOwned(String resource,  ResultSet result) throws LackException {
         if (result.isExhausted()) {
             throw new LackException(String.format(MESSAGE_ACQUIRE, resource));
         }

--- a/lack/src/main/java/io/datanerds/lack/Messages.java
+++ b/lack/src/main/java/io/datanerds/lack/Messages.java
@@ -3,6 +3,7 @@ package io.datanerds.lack;
 public interface Messages {
 
     String MESSAGE_ACQUIRE = "Could not acquire lock for '%s'";
+    String MESSAGE_LOCK_TAKEN = "Lock for '%s' already held by '%s'";
     String MESSAGE_RENEW = "Could not renew lock for '%s'";
     String MESSAGE_RELEASE = "Could not release lock for '%s'";
 

--- a/lack/src/main/java/io/datanerds/lack/cassandra/Statements.java
+++ b/lack/src/main/java/io/datanerds/lack/cassandra/Statements.java
@@ -55,7 +55,7 @@ public class Statements {
 
     public void setTtl(int ttl) {
         logger.info("Setting a default TTL of '{}' seconds", ttl);
-        session.execute(alterTable("leases").withOptions().defaultTimeToLive(ttl));
+        session.execute(alterTable(TABLE).withOptions().defaultTimeToLive(ttl));
     }
 
     public ResultSet acquire(String resource, String owner) {

--- a/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
+++ b/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
@@ -65,11 +65,10 @@ public class CachedLackTest {
     @Test
     public void alreadyLocked() throws LackException {
         cachedLack.acquire(resource);
-        thrown.expect(LackException.class);
         cachedLack.acquire(resource);
 
         verify(cache, times(2)).getIfPresent(resource);
-        verify(cache, times(1)).put(resource, true);
+        verify(cache, times(3)).put(resource, true);
         verify(cache, never()).put(resource, false);
     }
 
@@ -78,14 +77,6 @@ public class CachedLackTest {
         cachedLack.acquire(resource);
         thrown.expect(LackException.class);
         otherCachedLack.acquire(resource);
-
-        verify(cache, times(1)).getIfPresent(resource);
-        verify(cache, times(1)).put(resource, true);
-        verify(cache, never()).put(resource, false);
-
-        verify(otherCache, times(1)).getIfPresent(resource);
-        verify(otherCache, never()).put(resource, true);
-        verify(otherCache, never()).put(resource, false);
     }
 
     @Test
@@ -94,14 +85,6 @@ public class CachedLackTest {
         cachedLack.release(resource);
         thrown.expect(LackException.class);
         otherCachedLack.release(resource);
-
-        verify(cache, times(1)).getIfPresent(resource);
-        verify(cache, never()).put(resource, true);
-        verify(cache, times(1)).put(resource, false);
-
-        verify(otherCache, never()).getIfPresent(resource);
-        verify(otherCache, never()).put(resource, true);
-        verify(otherCache, never()).put(resource, false);
     }
 
     @Test

--- a/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
+++ b/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
@@ -9,7 +9,6 @@ import org.junit.*;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.UUID;
@@ -65,11 +64,8 @@ public class CachedLackTest {
     @Test
     public void alreadyLocked() throws LackException {
         cachedLack.acquire(resource);
+        thrown.expect(LackException.class);
         cachedLack.acquire(resource);
-
-        verify(cache, times(2)).getIfPresent(resource);
-        verify(cache, times(3)).put(resource, true);
-        verify(cache, never()).put(resource, false);
     }
 
     @Test

--- a/lack/src/test/java/io/datanerds/lack/LackTest.java
+++ b/lack/src/test/java/io/datanerds/lack/LackTest.java
@@ -3,7 +3,6 @@ package io.datanerds.lack;
 import io.datanerds.lack.cassandra.LackConfig;
 import org.cassandraunit.CassandraCQLUnit;
 import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
 
@@ -43,6 +42,13 @@ public class LackTest {
     }
 
     @Test
+    public void alreadyLocked() throws LackException {
+        lack.acquire(resource);
+        thrown.expect(LackException.class);
+        lack.acquire(resource);
+    }
+
+    @Test
     public void alreadyLockedByOther() throws LackException {
         lack.acquire(resource);
         thrown.expect(LackException.class);
@@ -75,21 +81,26 @@ public class LackTest {
     }
 
     @Test
-    public void reacquireLocks() throws LackException, InterruptedException {
+    public void claimLocks() throws LackException, InterruptedException {
         lack.acquire(resource);
         Thread.sleep(2000);
-        lack.acquire(resource);
+        lack.claim(resource);
         Thread.sleep(1500);
         thrown.expect(LackException.class);
         otherLack.acquire(resource);
     }
 
     @Test
-    public void reacquireWithoutRenewLocks() throws LackException, InterruptedException {
-        lack.acquire(resource);
-        Thread.sleep(2000);
-        lack.acquire(resource, false);
-        Thread.sleep(1500);
-        otherLack.acquire(resource);
+    public void simpleClaimRenewAndRelease() throws LackException {
+        lack.claim(resource);
+        lack.renew(resource);
+        lack.release(resource);
     }
+
+    @Test
+    public void claimTwice() throws LackException {
+        lack.claim(resource);
+        lack.claim(resource);
+    }
+
 }


### PR DESCRIPTION
- Acquiring owned lock does not throw exception anymore
- Lease renewal upon reacquiring owned lock is parameterized (default _true_)
- Removed uncalled verifaction code in tests
- Removed redundant call to start embedded server (done by
   CassandraCQLUnit test rule)
- Added tests for renew method and increased test _ttl_ for the actually test
   (accuracy in C\* seems to be seconds)
- Added tests for new functionality
