### PR TITLE
Fixed transitive dependency for Guava

### DIFF
--- a/lack/build.gradle
+++ b/lack/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile(
-            ["com.datastax.cassandra:cassandra-driver-core:$cassandraVersion"]
+            ["com.datastax.cassandra:cassandra-driver-core:$cassandraVersion",
+             "com.google.guava:guava:18.0"]
     )
     testCompile(
             ["org.cassandraunit:cassandra-unit-shaded:2.1.9.2"]

--- a/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
+++ b/lack/src/test/java/io/datanerds/lack/CachedLackTest.java
@@ -36,18 +36,18 @@ public class CachedLackTest {
     public static CassandraCQLUnit cassandraCQLUnit = new CassandraCQLUnit(
             new ClassPathCQLDataSet("setup.cql", "lack"));
 
-
-    @BeforeClass
-    public static void setupCassandra() throws Exception {
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
-    }
-
     @Before
     public void setup() {
         this.resource = UUID.randomUUID().toString();
 
         cachedLack = new CachedLack(config, "lack", cache);
         otherCachedLack = new CachedLack(config, "otherLack", otherCache);
+    }
+
+    @After
+    public void tearDown() {
+        cachedLack.stop();
+        otherCachedLack.stop();
     }
 
     @Test


### PR DESCRIPTION
- Added dependency for Guava since we're using the library in our code
- Removed redundant call to start the embedded Cassandra
- Added tear down method for cache tests
